### PR TITLE
Add GPU implementation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,15 +13,10 @@ stages:
   stage: build
   variables:
     version: "3.7"
-    build: "0"
+    build: "2"
   before_script:
-    - wget https://cmake.org/files/v$version/cmake-$version.$build.tar.gz
-    - tar -xzvf cmake-$version.$build.tar.gz
-    - cd cmake-$version.$build/
-    - ./bootstrap
-    - make -j2
-    - sudo make install
-    - cd -
+    - wget https://cmake.org/files/v$version/cmake-$version.$build-Linux-x86_64.sh
+    - sh ./cmake-$version.$build-Linux-x86_64.sh --prefix=/usr/local --skip-license
   script:
     - mkdir build
     - cd build
@@ -42,15 +37,11 @@ stages:
   stage: build
   variables:
     version: "3.7"
-    build: "0"
+    build: "2"
   before_script:
-    - wget https://cmake.org/files/v$version/cmake-$version.$build.tar.gz
-    - tar -xzvf cmake-$version.$build.tar.gz
-    - cd cmake-$version.$build/
-    - ./bootstrap
-    - make -j2
-    - sudo make install
-    - cd -
+    - apt update && apt install -y --no-install-recommends wget ca-certificates
+    - wget https://cmake.org/files/v$version/cmake-$version.$build-Linux-x86_64.sh
+    - sh ./cmake-$version.$build-Linux-x86_64.sh --prefix=/usr/local --skip-license
   script:
     - mkdir build
     - cd build
@@ -85,11 +76,11 @@ build:gcc-4:
   <<: *build_cpu_tdef
 
 build:cuda-8:
-  image: nvidia/cuda:8.0
+  image: nvidia/cuda:8.0-devel
   <<: *build_gpu_tdef
 
 build:cuda-9:
-  image: nvidia/cuda:9.0
+  image: nvidia/cuda:9.0-devel
   <<: *build_gpu_tdef
 
 #
@@ -173,13 +164,13 @@ test:gcc-4:
     - build:gcc-4
 
 test:cuda-8:
-  image: nvidia/cuda:8
+  image: nvidia/cuda:8.0-devel
   <<: *test_gpu_tdef
   dependencies:
     - build:cuda-8
 
 test:cuda-9:
-  image: nvidia/cuda:9
+  image: nvidia/cuda:9.0-devel
   <<: *test_gpu_tdef
   dependencies:
     - build:cuda-9

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ stages:
   script:
     - mkdir build
     - cd build
-    - cmake ../C
+    - cmake ../C -DENABLE_ERROR_INJECTION=ON
     - make
     - make install
   tags:
@@ -27,9 +27,8 @@ stages:
     when: on_success
     expire_in: 1h
     paths:
-      - /usr/local/MemoryReliability
+      - build/MemoryReliability
   dependencies: []
-
 
 build:gcc-7:
   image: gcc:7
@@ -56,10 +55,18 @@ build:gcc-4:
 ##
 .job_test_template: &test_tdef
   stage: test
+  before_script:
+    - apt update
+    - apt install -y --no-install-recommends kmod
+    - lsmod | grep msr
+    - ls -la /dev/cpu/
+    - ls -la /usr/local
   script:
-    - /usr/local/MemoryReliability -d -m 1024 -s 10 -o output.log -e output.err
-    - sleep 120
-    - /usr/local/
+    - build/MemoryReliability -d -m 1024 -s 1 -o output.log -e output.err
+    - sleep 40
+    - build/MemoryReliability -c
+    - cat output.log
+    - cat output.err
   tags:
     - cpu
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,37 @@
+#default image (docker best practices advice against using :latest tags, be advised)
+image: gcc:7
+
+stages:
+  - build
+
+.job_template: &job_tdef
+  stage: build
+  before_script:
+    - apt update
+    - apt install -y --no-install-recommends cmake
+  script:
+    - mkdir build
+    - cd build
+    - cmake ../C
+    - make
+    - make install
+  tags:
+    - cpu
+  dependencies: []
+    
+    
+sdc_build:gcc-7:
+  image: gcc:7
+  <<: *job_tdef
+
+sdc_build:gcc-6:
+  image: gcc:6
+  <<: *job_tdef
+  
+sdc_build:gcc-5:
+  image: gcc:5
+  <<: *job_tdef
+  
+sdc_build:gcc-4:
+  image: gcc:4
+  <<: *job_tdef

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,13 @@ image: gcc:7
 
 stages:
   - build
+  - test
 
-.job_template: &job_tdef
+#
+## stage: build
+#
+
+.job_build_template: &build_tdef
   stage: build
   before_script:
     - apt update
@@ -17,21 +22,76 @@ stages:
     - make install
   tags:
     - cpu
+  artifacts:
+    name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}_build"
+    when: on_success
+    expire_in: 1h
+    paths:
+      - /usr/local/MemoryReliability
   dependencies: []
-    
-    
-sdc_build:gcc-7:
-  image: gcc:7
-  <<: *job_tdef
 
-sdc_build:gcc-6:
+
+build:gcc-7:
+  image: gcc:7
+  <<: *build_tdef
+
+build:gcc-6:
   image: gcc:6
-  <<: *job_tdef
-  
-sdc_build:gcc-5:
+  <<: *build_tdef
+
+build:gcc-5:
   image: gcc:5
-  <<: *job_tdef
-  
-sdc_build:gcc-4:
+  <<: *build_tdef
+
+build:gcc-4:
   image: gcc:4
-  <<: *job_tdef
+  <<: *build_tdef
+
+#
+## stage: test
+#
+
+##
+## WARNING: MemoryReliability requires 'msr' kernel module!
+##
+.job_test_template: &test_tdef
+  stage: test
+  script:
+    - /usr/local/MemoryReliability -d -m 1024 -s 10 -o output.log -e output.err
+    - sleep 120
+    - /usr/local/
+  tags:
+    - cpu
+  artifacts:
+    name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}_test"
+    when: on_success
+    expire_in: 1h
+    paths:
+      - output.log
+      - output.err
+
+test:gcc-7:
+  image: gcc:7
+  <<: *test_tdef
+  dependencies:
+    - build:gcc-7
+
+test:gcc-6:
+  image: gcc:6
+  <<: *test_tdef
+  dependencies:
+    - build:gcc-6
+
+test:gcc-5:
+  image: gcc:5
+  <<: *test_tdef
+  dependencies:
+    - build:gcc-5
+
+test:gcc-4:
+  image: gcc:4
+  <<: *test_tdef
+  dependencies:
+    - build:gcc-4
+
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,11 +9,19 @@ stages:
 ## stage: build
 #
 
-.job_build_template: &build_tdef
+.job_build_template: &build_cpu_tdef
   stage: build
+  variables:
+    version: "3.7"
+    build: "0"
   before_script:
-    - apt update
-    - apt install -y --no-install-recommends cmake
+    - wget https://cmake.org/files/v$version/cmake-$version.$build.tar.gz
+    - tar -xzvf cmake-$version.$build.tar.gz
+    - cd cmake-$version.$build/
+    - ./bootstrap
+    - make -j2
+    - sudo make install
+    - cd -
   script:
     - mkdir build
     - cd build
@@ -30,21 +38,59 @@ stages:
       - build/MemoryReliability
   dependencies: []
 
+.job_build_cuda_template: &build_gpu_tdef
+  stage: build
+  variables:
+    version: "3.7"
+    build: "0"
+  before_script:
+    - wget https://cmake.org/files/v$version/cmake-$version.$build.tar.gz
+    - tar -xzvf cmake-$version.$build.tar.gz
+    - cd cmake-$version.$build/
+    - ./bootstrap
+    - make -j2
+    - sudo make install
+    - cd -
+  script:
+    - mkdir build
+    - cd build
+    - cmake ../C -DENABLE_ERROR_INJECTION=ON -DENABLE_CUDA=ON
+    - make
+    - make install
+  tags:
+    - gpu
+  artifacts:
+    name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}_build"
+    when: on_success
+    expire_in: 1h
+    paths:
+      - build/MemoryReliability
+  dependencies: []
+
+
 build:gcc-7:
   image: gcc:7
-  <<: *build_tdef
+  <<: *build_cpu_tdef
 
 build:gcc-6:
   image: gcc:6
-  <<: *build_tdef
+  <<: *build_cpu_tdef
 
 build:gcc-5:
   image: gcc:5
-  <<: *build_tdef
+  <<: *build_cpu_tdef
 
 build:gcc-4:
   image: gcc:4
-  <<: *build_tdef
+  <<: *build_cpu_tdef
+
+build:cuda-8:
+  image: nvidia/cuda:8.0
+  <<: *build_gpu_tdef
+
+build:cuda-9:
+  image: nvidia/cuda:9.0
+  <<: *build_gpu_tdef
 
 #
 ## stage: test
@@ -53,7 +99,7 @@ build:gcc-4:
 ##
 ## WARNING: MemoryReliability requires 'msr' kernel module!
 ##
-.job_test_template: &test_tdef
+.job_test__cpu_template: &test_cpu_tdef
   stage: test
   before_script:
     - apt update
@@ -62,7 +108,7 @@ build:gcc-4:
     - ls -la /dev/cpu/
     - ls -la /usr/local
   script:
-    - build/MemoryReliability -d -m 1024 -s 1 -o output.log -e output.err
+    - build/MemoryReliability -d --cpu -m 1024 -s 1 -o output.log -e output.err
     - sleep 40
     - build/MemoryReliability -c
     - cat output.log
@@ -77,28 +123,65 @@ build:gcc-4:
       - output.log
       - output.err
 
+.job_test_gpu_template: &test_gpu_tdef
+  stage: test
+  before_script:
+    - apt update
+    - apt install -y --no-install-recommends kmod
+    - lsmod | grep msr
+    - ls -la /dev/cpu/
+    - ls -la /usr/local
+  script:
+    - build/MemoryReliability -d --gpu -m 1024 -s 1 -o output.log -e output.err
+    - sleep 40
+    - build/MemoryReliability -c
+    - cat output.log
+    - cat output.err
+  tags:
+    - gpu
+  artifacts:
+    name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}_test"
+    when: on_success
+    expire_in: 1h
+    paths:
+      - output.log
+      - output.err
+
+
 test:gcc-7:
   image: gcc:7
-  <<: *test_tdef
+  <<: *test_cpu_tdef
   dependencies:
     - build:gcc-7
 
 test:gcc-6:
   image: gcc:6
-  <<: *test_tdef
+  <<: *test_cpu_tdef
   dependencies:
     - build:gcc-6
 
 test:gcc-5:
   image: gcc:5
-  <<: *test_tdef
+  <<: *test_cpu_tdef
   dependencies:
     - build:gcc-5
 
 test:gcc-4:
   image: gcc:4
-  <<: *test_tdef
+  <<: *test_cpu_tdef
   dependencies:
     - build:gcc-4
+
+test:cuda-8:
+  image: nvidia/cuda:8
+  <<: *test_gpu_tdef
+  dependencies:
+    - build:cuda-8
+
+test:cuda-9:
+  image: nvidia/cuda:9
+  <<: *test_gpu_tdef
+  dependencies:
+    - build:cuda-9
 
 

--- a/C/CMakeLists.txt
+++ b/C/CMakeLists.txt
@@ -1,12 +1,58 @@
-cmake_minimum_required (VERSION 2.6)
+# We need FindCUDA functionalities present in cmake >= 3.7
+cmake_minimum_required (VERSION 3.7)
 project (MemoryReliability)
+
 option(ENABLE_ERROR_INJECTION "Inject randomly errors in allocated memory region" OFF)
 if(ENABLE_ERROR_INJECTION)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DINJECT_ERR")
 endif()
-add_executable(MemoryReliability MemoryReliability.c)
-include_directories("${CMAKE_SOURCE_DIR}/include")
-set(MRLIB_SRC ${CMAKE_SOURCE_DIR}/lib/addresstranslation.c ${CMAKE_SOURCE_DIR}/lib/logging.c ${CMAKE_SOURCE_DIR}/lib/MemoryReliability_defs.c ${CMAKE_SOURCE_DIR}/lib/pmu.c ${CMAKE_SOURCE_DIR}/lib/tools.c)
+
+option(ENABLE_CUDA "Test GPU memory" ON)
+find_package(CUDA)
+if (ENABLE_CUDA AND CUDA_FOUND)
+    add_definitions(-DUSE_CUDA)
+
+    set(CUDA_PROPAGATE_HOST_FLAGS ON)
+
+    set(CUDA_NVCC_FLAGS "-std=c++11 ${CUDA_NVCC_FLAGS} -gencode arch=compute_30,code=\"sm_30,sm_35,sm_37\" -gencode arch=compute_50,code=sm_52 -gencode arch=compute_60,code=\"sm_60,sm_61\" -lineinfo")
+    set(CUDA_NVCC_FLAGS_DEBUG   "-O0 -g -G")
+    set(CUDA_NVCC_FLAGS_RELEASE "-O3       -res-usage")
+
+    message(STATUS "--------------------------------------")
+    message(STATUS "----[CUDA ENABLED] :                  ")
+    message(STATUS "---- CUDA_VERSION:      ${CUDA_VERSION} (${CUDA_VERSION_STRING})")
+    message(STATUS "---- CUDA_TOOLKIT_DIR:  ${CUDA_TOOLKIT_ROOT_DIR}")
+    message(STATUS "---- CUDA_INCLUDE_DIRS: ${CUDA_INCLUDE_DIRS}")
+    message(STATUS "---- CUDA_LIBRARIES:    ${CUDA_LIBRARIES}")
+    message(STATUS "--------                      --------")
+    message(STATUS "---- CUDA_HOST_COMPILER: ${CUDA_HOST_COMPILER}")
+    message(STATUS "--------------------------------------")
+
+elseif(ENABLE_CUDA AND NOT CUDA_FOUND)
+    message(INFO "CUDA not found")
+else()
+endif()
+
+set(MRLIB_SRC
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/addresstranslation.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/logging.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/MemoryReliability_defs.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/pmu.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib/tools.c)
 add_library(MRlib STATIC ${MRLIB_SRC})
+target_include_directories(MRlib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+if (ENABLE_CUDA AND CUDA_FOUND)
+    cuda_add_library(MRlib-cuda STATIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/tools.cu)
+    set_target_properties(MRlib-cuda PROPERTIES CXX_STANDARD 11)
+    target_include_directories(MRlib-cuda PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+    target_include_directories(MRlib PUBLIC ${CUDA_INCLUDE_DIRS})
+    target_link_libraries(MRlib MRlib-cuda stdc++ ${CUDA_LIBRARIES})
+endif()
+
+add_executable(MemoryReliability MemoryReliability.c)
+target_include_directories(MemoryReliability PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(MemoryReliability MRlib)
+
 install(TARGETS MemoryReliability DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/C/CMakeLists.txt
+++ b/C/CMakeLists.txt
@@ -80,15 +80,20 @@ message(STATUS "CUDA_NVCC_FLAGS_DEBUG:          ${CUDA_NVCC_FLAGS_DEBUG}")
 message(STATUS "CUDA_NVCC_FLAGS_RELEASE:        ${CUDA_NVCC_FLAGS_RELEASE}")
 message(STATUS "----------------------------------------")
 
+add_library(addr    ${CMAKE_CURRENT_SOURCE_DIR}/lib/addresstranslation.c)
+target_include_directories(addr PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+add_library(logging ${CMAKE_CURRENT_SOURCE_DIR}/lib/logging.c)
+target_include_directories(logging PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(logging addr)
 
 set(MRLIB_SRC
-        ${CMAKE_CURRENT_SOURCE_DIR}/lib/addresstranslation.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/lib/logging.c
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/MemoryReliability_defs.c
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/pmu.c
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/tools.c)
 add_library(MRlib STATIC ${MRLIB_SRC})
 target_include_directories(MRlib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(MRlib logging)
 
 if (ENABLE_CUDA AND CUDA_FOUND)
     cuda_add_library(MRlib-cuda STATIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/tools.cu)

--- a/C/CMakeLists.txt
+++ b/C/CMakeLists.txt
@@ -2,6 +2,20 @@
 cmake_minimum_required (VERSION 3.7)
 project (MemoryReliability)
 
+# Default build type
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+   message(STATUS "No build type selected, defaulting to Release")
+   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type (default Release)" FORCE)
+endif()
+
+# Restrict to only DEBUG | RELEASE | RELWITHDEBINFO :
+string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+if (CMAKE_BUILD_TYPE AND
+      NOT uppercase_CMAKE_BUILD_TYPE MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO)$")
+   message(FATAL_ERROR "Invalid value for CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+endif()
+
+# Project options
 option(ENABLE_ERROR_INJECTION "Inject randomly errors in allocated memory region" OFF)
 if(ENABLE_ERROR_INJECTION)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DINJECT_ERR")
@@ -32,6 +46,40 @@ elseif(ENABLE_CUDA AND NOT CUDA_FOUND)
     message(INFO "CUDA not found")
 else()
 endif()
+
+
+# C Standard
+set(CMAKE_C_STANDARD_REQUIRED 99)
+
+# Compile flags
+if (("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR
+    ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang"))
+    # gcc/clang flags
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
+    # icc flags
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
+    # pgcc flags
+else ()
+    message(WARNING "Compiler not supported!")
+endif ()
+
+message(STATUS "----------------------------------------")
+message(STATUS "-----------  SDCfinder    --------------")
+message(STATUS "----------------------------------------")
+message(STATUS "CPU TYPE:                       ${CMAKE_SYSTEM_PROCESSOR}")
+message(STATUS "BUILD TYPE:                     ${CMAKE_BUILD_TYPE}")
+message(STATUS "CMAKE_C_FLAGS:                  ${CMAKE_C_FLAGS}")
+message(STATUS "CMAKE_C_FLAGS_DEBUG:            ${CMAKE_C_FLAGS_DEBUG}")
+message(STATUS "CMAKE_C_FLAGS_RELEASE:          ${CMAKE_C_FLAGS_RELEASE}")
+message(STATUS "CMAKE_EXE_LINKER_FLAGS:         ${CMAKE_EXE_LINKER_FLAGS}")
+message(STATUS "CMAKE_EXE_LINKER_FLAGS_DEBUG:   ${CMAKE_EXE_LINKER_FLAGS_DEBUG}")
+message(STATUS "CMAKE_EXE_LINKER_FLAGS_RELEASE: ${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
+message(STATUS "CUDA_NVCC_FLAGS:                ${CUDA_NVCC_FLAGS}")
+message(STATUS "CUDA_NVCC_FLAGS_DEBUG:          ${CUDA_NVCC_FLAGS_DEBUG}")
+message(STATUS "CUDA_NVCC_FLAGS_RELEASE:        ${CUDA_NVCC_FLAGS_RELEASE}")
+message(STATUS "----------------------------------------")
+
 
 set(MRLIB_SRC
         ${CMAKE_CURRENT_SOURCE_DIR}/lib/addresstranslation.c

--- a/C/CMakeLists.txt
+++ b/C/CMakeLists.txt
@@ -99,6 +99,7 @@ if (ENABLE_CUDA AND CUDA_FOUND)
     cuda_add_library(MRlib-cuda STATIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/tools.cu)
     set_target_properties(MRlib-cuda PROPERTIES CXX_STANDARD 11)
     target_include_directories(MRlib-cuda PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    target_link_libraries(MRlib-cuda logging)
 
     target_include_directories(MRlib PUBLIC ${CUDA_INCLUDE_DIRS})
     target_link_libraries(MRlib MRlib-cuda stdc++ ${CUDA_LIBRARIES})

--- a/C/CMakeLists.txt
+++ b/C/CMakeLists.txt
@@ -49,7 +49,8 @@ endif()
 
 
 # C Standard
-set(CMAKE_C_STANDARD_REQUIRED 99)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Compile flags
 if (("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR

--- a/C/MemoryReliability.c
+++ b/C/MemoryReliability.c
@@ -69,6 +69,9 @@
  ============================================================================
  Support for GPU memory tests, Dec 2017.
  Authors     : Pau Farre, Marc Jorda
+ Organization: Accelerators and Communications for HPC Team,
+               Barcelona Supercomputing Center
+ Contact: accelcom@bsc.es
  ============================================================================
  */
 

--- a/C/MemoryReliability.c
+++ b/C/MemoryReliability.c
@@ -31,7 +31,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ============================================================================
  Name        : MemoryReliability.c
- Authors     : Ferad Zyulkyarov, Kai Keller, Leonardo Bautista-Gomez
+ Authors     : Ferad Zyulkyarov, Kai Keller, Leonardo Bautista-Gomez,
+               Pau Farre, Marc Jorda
  Version     :
  Copyright   :
  Description : A daemon which tests the memory for errors.
@@ -65,6 +66,9 @@
  ============================================================================
  Adaptation for Mare Nostrum IV, Oct 2017.
  Author      : Kai Keller
+ ============================================================================
+ Support for GPU memory tests, Dec 2017.
+ Authors     : Pau Farre, Marc Jorda
  ============================================================================
  */
 

--- a/C/MemoryReliability.c
+++ b/C/MemoryReliability.c
@@ -68,7 +68,7 @@
  ============================================================================
  */
 
-#include "include/MemoryReliability_decl.h"
+#include "MemoryReliability_decl.h"
 
 //
 // The main daemon task
@@ -76,7 +76,7 @@
 
 int main(int argc, char* argv[])
 {
-	char is_init = parse_arguments(argc, argv);
+	bool is_init = parse_arguments(argc, argv);
 	if (!is_init)
 	{
 		print_usage(argv[0]);
@@ -100,11 +100,10 @@ int main(int argc, char* argv[])
 	return EXIT_SUCCESS;
 }
 
-unsigned char parse_arguments(int argc, char* argv[])
+bool parse_arguments(int argc, char* argv[])
 {
 	int i = 1;
 	unsigned int mega = 0;
-	unsigned char is_success = 0;
 
     srand(time(NULL));
     unsigned char BinExpo = rand()%4;
@@ -124,15 +123,36 @@ unsigned char parse_arguments(int argc, char* argv[])
 		{
 			IsDaemonStart = 1;
 		}
-		if (strcmp(argv[i], "-m") == 0)
-		{
-			i++;
-			mega = (unsigned int)atoi(argv[i]);
-			NumBytes = (unsigned long long)mega * (unsigned long long)MEGA;
-            if (NumBytes%8 != 0) {
-                printf("The number of Bytes has to be a multiple of 8");
+        if (strcmp(argv[i], "--cpu") == 0)
+        {
+            i++;
+            CheckCPU = 1;
+
+            if (strcmp(argv[i], "-m") == 0)
+            {
+                i++;
+                unsigned int mega = (unsigned int)atoi(argv[i]);
+                NumBytesCPU = (unsigned long long)mega * (unsigned long long)MEGA;
+                if (NumBytesCPU%8 != 0) {
+                    printf("The number of Bytes has to be a multiple of 8");
+                }
             }
-		}
+        }
+        if (strcmp(argv[i], "--gpu") == 0)
+        {
+            i++;
+            CheckGPU = 1;
+
+            if (strcmp(argv[i], "-m") == 0)
+            {
+                i++;
+                unsigned int mega = (unsigned int)atoi(argv[i]);
+                NumBytesGPU = (unsigned long long)mega * (unsigned long long)MEGA;
+                if (NumBytesGPU%8 != 0) {
+                    printf("The number of Bytes has to be a multiple of 8");
+                }
+            }
+        }
 		if (strcmp(argv[i], "-o") == 0)
 		{
 			i++;
@@ -163,8 +183,16 @@ unsigned char parse_arguments(int argc, char* argv[])
 	if (!IsDaemonStop)
 	{
 		printf("Host name: %s\n", HostName);
-		printf("Memory size: %llu bytes = %llu MB\n", NumBytes, NumBytes/MEGA);
-        printf("Memory pattern (hex): 0x%" PRIxPTR "\n", mem_pattern);
+        if (CheckCPU)
+        {
+            printf("CPU Memory size: %llu bytes = %llu MB\n", NumBytesCPU, NumBytesCPU/MEGA);
+            printf("CPU Memory pattern (hex): 0x%" PRIxPTR "\n", mem_pattern);
+        }
+        if (CheckGPU)
+        {
+            printf("GPU Memory size: %llu bytes = %llu MB\n", NumBytesGPU, NumBytesGPU/MEGA);
+            printf("GPU Memory pattern (hex): 0x%" PRIxPTR "\n", mem_pattern);
+        }
 		printf("Log file: %s\n", OutFile);
 		printf("Error log file: %s\n", ErrFile);
 		printf("Sleep time: %u\n", SleepTime);
@@ -172,7 +200,7 @@ unsigned char parse_arguments(int argc, char* argv[])
 		printf("Warning file: %s\n", WarningFile);
 	}
 
-	is_success = (NumBytes != 0) || (IsDaemonStop);
+	bool is_success = (CheckCPU && NumBytesCPU != 0) || (CheckGPU && NumBytesGPU != 0) || (IsDaemonStop);
 
 	if ((WarningRate > 0 && strlen(WarningFile) == 0) || (WarningRate == 0 && strlen(WarningFile) > 0))
 	{
@@ -186,22 +214,26 @@ void print_usage(char* program_name)
 {
 	printf("Memory scanner by Ferad Zyulkyarov\n");
 	printf("This program starts a daemon for memory test or stops an already running daemon.\n");
-	printf("Options: [-d] [-c] -m [-o] [-s] [-wn] [-wf]\n");
+	printf("Options: [-d] [-c] [--cpu [-m]] [--gpu [-m]] [-o] [-s] [-wn] [-wf]\n");
 	printf("    -d: start as daemon. If not passed will start as a foreground process.\n");
 	printf("    -c: stop the daemon.\n");
-	printf("    -m: the size of the memory to test in MB.\n");
+    printf("    --cpu: check CPU memory.\n");
+    printf("    -m: the size of the CPU memory to test in MB.\n");
+    printf("    --gpu: check GPU memory.\n");
+    printf("    -m: the size of the GPU memory to test in MB.\n");
 	printf("    -o: log file name [default=%s].\n", OutFile);
 	printf("    -e: error file name [default=%s].\n", ErrFile);
 	printf("    -s: sleep time in seconds [default=%u].\n", SleepTime);
 	printf("    -wn: warning rate [default=%u].\n", WarningRate);
 	printf("    -wf: warning file [default=%s].\n", WarningFile);
 	printf("Example to start a daemon:\n");
-	printf("    %s -d -m 1024 -s 10 -o full_path_to_logfile.log -- run as a daemon, test 1024MB of memory, and sleep for 10sec, write logs to logfile.log.\n", program_name);
-	printf("    %s -d -m 1024 -s 10 -o full_path_to_logfile.log -wn 15 -wf full_path_to_warningfile.txt -- run as a daemon, test 1024MB of memory, and sleep for 10sec, write logs to logfile.log, if there are more than (-wn) 10 errors detected write the name of the host to file warning.txt\n", program_name);
-	printf("Example to stop a daemon: \n");
+	printf("    %s -d --cpu -m 1024 -s 10 -o full_path_to_logfile.log -- run as a daemon, test 1024MB of CPU memory, and sleep for 10sec, write logs to logfile.log.\n", program_name);
+	printf("    %s -d --cpu -m 1024 -s 10 -o full_path_to_logfile.log -wn 15 -wf full_path_to_warningfile.txt -- run as a daemon, test 1024MB of CPU memory, and sleep for 10sec, write logs to logfile.log, if there are more than (-wn) 10 errors detected write the name of the host to file warning.txt\n", program_name);
+    printf("    %s -d --cpu -m 1024 --gpu -m 2048 -s 5 -o full_path_to_logfile.log -wn 15 -wf full_path_to_warningfile.txt -- run as a daemon, test 1024MB of CPU memory, test 2048MB of GPU memory, and sleep for 5sec, write logs to logfile.log, if there are more than (-wn) 10 errors detected write the name of the host to file warning.txt\n", program_name);
+    printf("Example to stop a daemon: \n");
 	printf("    %s -c\n", program_name);
 	printf("Example to run as a foreground process:\n");
-	printf("    %s -m 1024 -s 10 -- run as a daemon, test 1024MB of memory, and sleep for 10sec.\n", program_name);
+	printf("    %s --cpu -mc 1024 -s 10 -- run as a daemon, test 1024MB of memory, and sleep for 10sec.\n", program_name);
 }
 
 void start_daemon()
@@ -258,9 +290,18 @@ void start_daemon()
 	//	log_message("ERROR_INFO,Cannot change the working directory.");
 	//	exit(EXIT_FAILURE);
 	//}
-
-	sprintf(start_msg, "START, ALLOCATED MEMORY (BYTES): %llu, PATTERN (HEX): 0x%" PRIxPTR ", SLEEP TIME (SECONDS): %u", NumBytes, mem_pattern, SleepTime);
-	log_message(start_msg);
+    sprintf(start_msg, "START, SLEEP TIME (SECONDS): %u", SleepTime);
+    log_message(start_msg);
+    if (CheckCPU)
+    {
+        sprintf(start_msg, "INFO, ALLOCATED CPU MEMORY (BYTES): %llu, PATTERN (HEX): 0x%" PRIxPTR, NumBytesCPU, mem_pattern);
+        log_message(start_msg);
+    }
+    if (CheckGPU)
+    {
+        sprintf(start_msg, "INFO, ALLOCATED GPU MEMORY (BYTES): %llu, PATTERN (HEX): 0x%" PRIxPTR , NumBytesGPU, mem_pattern);
+        log_message(start_msg);
+    }
 	printf("Daemon started\n");
 
 	//
@@ -281,12 +322,21 @@ void start_daemon()
 	//
 	signal(SIGHUP, SIG_IGN);
 
+    // Initialize the memory before entering the daemon loop
+    if (CheckCPU)
+        initialize_cpu_memory();
+    if (CheckGPU)
+        initialize_gpu_memory();
+
 	//
 	// The daemon loop.
 	//
-	initialize_memory();
-	//simple_memory_test(Mem, NumBytes);
-	random_pattern_test(Mem, NumBytes);
+    memory_test_loop(RANDOM);
+
+    if (CheckCPU)
+        free_cpu_memory();
+    if (CheckGPU)
+        free_gpu_memory();
 
 	exit(EXIT_SUCCESS);
 }
@@ -333,12 +383,33 @@ void start_client()
 	signal(SIGINT, sigint_signal_handler);
 
 	printf("Client started...\n");
-	sprintf(start_msg, "START, ALLOCATED MEMORY (BYTES): %llu, PATTERN (HEX): 0x%" PRIxPTR ", SLEEP TIME (SECONDS): %u", NumBytes, mem_pattern, SleepTime);
-	log_message(start_msg);
 
-	initialize_memory();
-	//simple_memory_test(Mem, NumBytes);
-	//zero_one_test(Mem, NumBytes);
-    random_pattern_test(Mem, NumBytes);
+    sprintf(start_msg, "START, SLEEP TIME (SECONDS): %u", SleepTime);
+    log_message(start_msg);
+    if (CheckCPU)
+    {
+        sprintf(start_msg, "INFO, ALLOCATED CPU MEMORY (BYTES): %llu, PATTERN (HEX): 0x%" PRIxPTR, NumBytesCPU, mem_pattern);
+        log_message(start_msg);
+    }
+    if (CheckGPU)
+    {
+        sprintf(start_msg, "INFO, ALLOCATED GPU MEMORY (BYTES): %llu, PATTERN (HEX): 0x%" PRIxPTR , NumBytesGPU, mem_pattern);
+        log_message(start_msg);
+    }
+
+    if (CheckCPU)
+        initialize_cpu_memory();
+    if (CheckGPU)
+        initialize_gpu_memory();
+
+    //
+    // The daemon loop.
+    //
+    memory_test_loop(RANDOM);
+
+    if (CheckCPU)
+        free_cpu_memory();
+    if (CheckGPU)
+        free_gpu_memory();
 }
 

--- a/C/MemoryReliability.c
+++ b/C/MemoryReliability.c
@@ -233,7 +233,7 @@ void print_usage(char* program_name)
     printf("Example to stop a daemon: \n");
 	printf("    %s -c\n", program_name);
 	printf("Example to run as a foreground process:\n");
-	printf("    %s --cpu -mc 1024 -s 10 -- run as a daemon, test 1024MB of memory, and sleep for 10sec.\n", program_name);
+	printf("    %s --cpu -m 1024 -s 10 -- run as a daemon, test 1024MB of memory, and sleep for 10sec.\n", program_name);
 }
 
 void start_daemon()

--- a/C/include/MemoryReliability_decl.cuh
+++ b/C/include/MemoryReliability_decl.cuh
@@ -1,0 +1,19 @@
+#ifndef _MEMORYRELIABILITY_DECL_CUH
+#define _MEMORYRELIABILITY_DECL_CUH
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void check_gpu_mem(uintptr_t* buffer,
+                   unsigned long long num_bytes,
+                   uintptr_t expected_value,
+                   uintptr_t new_value);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/C/include/MemoryReliability_decl.cuh
+++ b/C/include/MemoryReliability_decl.cuh
@@ -7,10 +7,10 @@
 extern "C" {
 #endif
 
-void check_gpu_mem(uintptr_t* buffer,
-                   unsigned long long num_bytes,
-                   uintptr_t expected_value,
-                   uintptr_t new_value);
+void check_gpu_stub(uintptr_t* buffer,
+                    unsigned long long num_bytes,
+                    uintptr_t expected_value,
+                    uintptr_t new_value);
 
 #ifdef __cplusplus
 };

--- a/C/include/MemoryReliability_decl.h
+++ b/C/include/MemoryReliability_decl.h
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 #include <time.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -42,14 +43,18 @@ unsigned int NumErrors;// = 0;
 
 char HostName[255];
 
-unsigned long long NumBytes;// = 0;
-void* Mem;// = NULL;
+unsigned long long NumBytesCPU;// = 0;
+unsigned long long NumBytesGPU;// = 0;
+void* cpu_mem;// = NULL;
+void* gpu_mem;// = NULL;
 unsigned char mem_pattern;
 
 unsigned int SleepTime;// = 0;
-unsigned char ExitNow;// = 0;
-unsigned char IsDaemonStart;// = 0;
-unsigned char IsDaemonStop;// = 0;
+bool ExitNow;// = 0;
+bool IsDaemonStart;// = 0;
+bool IsDaemonStop;// = 0;
+bool CheckCPU;
+bool CheckGPU;
 
 // FUNCTIONS
 void log_error(void* address, ADDRVALUE actual_value, ADDRVALUE expected_value);
@@ -57,14 +62,21 @@ void log_message(char* message);
 void warn_for_errors();
 void log_local_mem_errors(int local_mem_errors); // Logs local memory errors
 
-void simple_memory_test(void* buffer, unsigned int num_bytes);
-void zero_one_test(void* buffer, unsigned int num_bytes);
-void random_pattern_test(void* buffer, unsigned int num_bytes);
+typedef enum Strategy {
+    SIMPLE = 0,
+    ZERO = 1,
+    RANDOM = 2
+} Strategy_t;
 
-unsigned char parse_arguments(int argc, char* argv[]);
-void print_usage();
+void memory_test_loop(Strategy_t type);
+
+bool parse_arguments(int argc, char* argv[]);
+void print_usage(char* program_name);
 void check_no_daemon_running();
-void initialize_memory();
+void initialize_cpu_memory();
+void initialize_gpu_memory();
+void free_cpu_memory();
+void free_gpu_memory();
 void start_daemon();
 void stop_daemon();
 void start_client();

--- a/C/include/MemoryReliability_decl.h
+++ b/C/include/MemoryReliability_decl.h
@@ -18,30 +18,16 @@
 
 #include "addresstranslation.h"
 #include "pmu.h"
+#include "types.h"
+#include "logging.h"
 
 // DEFINITIONS
-typedef uintptr_t ADDRVALUE;
-typedef void* ADDRESS;
 
-const unsigned int TCC_ACT_TEMP;//         = 100; // TCC activation temperature
-const unsigned int TEMP_FIELD_LOW_BIT;//   = 16; // low bit of 6 bit temp value
-const unsigned int TEMP_FIELD_OFFSET;//    = 412; // offset in /dev/cpu/#cpu/msr file
-uint64_t TEMP_FIELD_MASK;//                = 0x00000000003f0000; // selects 6 bit field[22:16]
-const unsigned int KILO;//                 = 1024;
-const unsigned int MEGA;//                 = 1048576;
-const unsigned int GIGA;//                 = 1073741824;
+extern const unsigned int KILO;//                 = 1024;
+extern const unsigned int MEGA;//                 = 1048576;
+extern const unsigned int GIGA;//                 = 1073741824;
 
 // STATIC VARIABLES
-char PidFileName[255];// = "pid.txt";
-char TemperatureFileName[255];// = "/sys/class/thermal/thermal_zone0/temp";
-char OutFile[255];// = "MemoryReliability.log";
-char WarningFile[255];// = "";
-char ErrFile[255];// = "MemoryReliability.err";
-
-unsigned int WarningRate;// = 0;
-unsigned int NumErrors;// = 0;
-
-char HostName[255];
 
 unsigned long long NumBytesCPU;// = 0;
 unsigned long long NumBytesGPU;// = 0;
@@ -49,24 +35,14 @@ void* cpu_mem;// = NULL;
 void* gpu_mem;// = NULL;
 unsigned char mem_pattern;
 
-unsigned int SleepTime;// = 0;
-bool ExitNow;// = 0;
-bool IsDaemonStart;// = 0;
-bool IsDaemonStop;// = 0;
+extern unsigned int SleepTime;// = 0;
+extern bool ExitNow;// = 0;
+extern bool IsDaemonStart;// = 0;
+extern bool IsDaemonStop;// = 0;
 bool CheckCPU;
 bool CheckGPU;
 
 // FUNCTIONS
-void log_error(void* address, ADDRVALUE actual_value, ADDRVALUE expected_value);
-void log_message(char* message);
-void warn_for_errors();
-void log_local_mem_errors(int local_mem_errors); // Logs local memory errors
-
-typedef enum Strategy {
-    SIMPLE = 0,
-    ZERO = 1,
-    RANDOM = 2
-} Strategy_t;
 
 void memory_test_loop(Strategy_t type);
 
@@ -89,6 +65,5 @@ unsigned char daemon_pid_file_exists();
 pid_t daemon_pid_read_from_file();
 void daemon_pid_delete_file();
 
-int read_temperature();
 
 #endif

--- a/C/include/addresstranslation.h
+++ b/C/include/addresstranslation.h
@@ -7,10 +7,7 @@
 #ifndef __ADDRESS_TRANSLATION_H
 #define __ADDRESS_TRANSLATION_H
 
-#include <inttypes.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <unistd.h>
 
 uintptr_t virtual_to_physical_address(uintptr_t virt_addr);
 

--- a/C/include/logging.h
+++ b/C/include/logging.h
@@ -1,0 +1,28 @@
+#ifndef LOGGING_H
+#define LOGGING_H
+
+#include "types.h"
+
+extern const unsigned int TCC_ACT_TEMP;//         = 100; // TCC activation temperature
+extern const unsigned int TEMP_FIELD_LOW_BIT;//   = 16; // low bit of 6 bit temp value
+extern const unsigned int TEMP_FIELD_OFFSET;//    = 412; // offset in /dev/cpu/#cpu/msr file
+extern uint64_t TEMP_FIELD_MASK;//                = 0x00000000003f0000; // selects 6 bit field[22:16]
+
+
+extern char PidFileName[255];// = "pid.txt";
+extern char TemperatureFileName[255];// = "/sys/class/thermal/thermal_zone0/temp";
+extern char OutFile[255];// = "MemoryReliability.log";
+extern char WarningFile[255];// = "";
+extern char ErrFile[255];// = "MemoryReliability.err";
+
+extern unsigned int WarningRate;// = 0;
+extern unsigned int NumErrors;// = 0;
+
+char HostName[255];
+
+void log_error(void* address, ADDRVALUE actual_value, ADDRVALUE expected_value);
+void log_message(char* message);
+void warn_for_errors();
+void log_local_mem_errors(int local_mem_errors); // Logs local memory errors
+
+#endif //LOGGING_H

--- a/C/include/types.h
+++ b/C/include/types.h
@@ -1,0 +1,15 @@
+#ifndef TYPES_H
+#define TYPES_H
+
+#include <stdint.h>
+
+typedef uintptr_t ADDRVALUE;
+typedef void* ADDRESS;
+
+typedef enum Strategy {
+    SIMPLE = 0,
+    ZERO = 1,
+    RANDOM = 2
+} Strategy_t;
+
+#endif //TYPES_H

--- a/C/lib/MemoryReliability_defs.c
+++ b/C/lib/MemoryReliability_defs.c
@@ -1,4 +1,4 @@
-#include "../include/MemoryReliability_decl.h"
+#include "MemoryReliability_decl.h"
 
 // DEFINITIONS
 const unsigned int TCC_ACT_TEMP         = 100; // TCC activation temperature
@@ -23,6 +23,6 @@ unsigned long long NumBytes = 0;
 void* Mem = NULL;
 
 unsigned int SleepTime = 0;
-unsigned char ExitNow = 0;
-unsigned char IsDaemonStart = 0;
-unsigned char IsDaemonStop = 0;
+bool ExitNow = false;
+bool IsDaemonStart = false;
+bool IsDaemonStop = false;

--- a/C/lib/addresstranslation.c
+++ b/C/lib/addresstranslation.c
@@ -6,6 +6,8 @@
 
 #include "addresstranslation.h"
 
+#include <stdio.h>
+#include <unistd.h>
 
 #define PAGEMAP_ENTRY 8
 #define GET_BIT(X,Y) (X & ((uint64_t)1<<Y)) >> Y

--- a/C/lib/addresstranslation.c
+++ b/C/lib/addresstranslation.c
@@ -4,7 +4,7 @@
  * Implements address translation from virtual to physical.
  */
 
-#include "../include/addresstranslation.h"
+#include "addresstranslation.h"
 
 
 #define PAGEMAP_ENTRY 8

--- a/C/lib/logging.c
+++ b/C/lib/logging.c
@@ -1,4 +1,5 @@
 #include "MemoryReliability_decl.h"
+#include <errno.h>
 
 void warn_for_errors()
 {
@@ -21,6 +22,7 @@ void log_error(void* address, ADDRVALUE actual_value, ADDRVALUE expected_value)
 	FILE *f = fopen(OutFile, "a+");
 	if (!f)
 	{
+        printf("ERROR, something went wrong opening file %s!: %s\n", OutFile, strerror(errno));
 		exit(EXIT_FAILURE);
 	}
     int field_width_value = 16;
@@ -46,6 +48,7 @@ void log_message(char* message)
 	FILE *f = fopen(OutFile, "a+");
 	if (!f)
 	{
+        printf("ERROR, something went wrong opening file %s!: %s\n", OutFile, strerror(errno));
 		exit(EXIT_FAILURE);
 	}
 	temperature = read_temperature();

--- a/C/lib/logging.c
+++ b/C/lib/logging.c
@@ -1,5 +1,69 @@
-#include "MemoryReliability_decl.h"
+#include "logging.h"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <errno.h>
+#include <time.h>
+
+#include <inttypes.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "addresstranslation.h"
+
+int read_temperature()
+{
+    int fd, fd_err, core = 0, ierr;
+    uint64_t temp;
+    char msr_file[32];
+    memset(msr_file, 0, 32);
+
+#ifdef SYS_getcpu
+    if (syscall(SYS_getcpu, &core, NULL, NULL) < 0) {
+        core = 0;
+    }
+#endif
+
+    fd_err = open(ErrFile, O_WRONLY|O_CREAT|O_APPEND, 0666);
+
+    snprintf(msr_file, 31, "/dev/cpu/%u/msr", core);
+    fd = open(msr_file, O_RDONLY);
+    if (fd == -1) {
+        ierr = errno;
+        dprintf(fd_err, "could not OPEN msr file: %s\n", strerror(ierr));
+        ierr = 0;
+        return -1;
+    }
+
+    ierr = pread(fd, &temp, sizeof(temp), TEMP_FIELD_OFFSET);
+    if (ierr == -1) {
+        ierr = errno;
+        dprintf(fd_err, "could not READ msr file: %s\n", strerror(ierr));
+        ierr = 0;
+        return -1;
+    }
+
+    temp &= TEMP_FIELD_MASK;
+    temp >>= TEMP_FIELD_LOW_BIT;
+    temp = TCC_ACT_TEMP - temp;
+
+    close(fd_err);
+    close(fd);
+
+    return temp;
+}
+
+time_t get_formatted_timestamp(char* out_time_formatted, unsigned char num_bytes)
+{
+    time_t rawtime;
+    struct tm *info;
+    time(&rawtime);
+    info = localtime(&rawtime);
+    strftime(out_time_formatted, num_bytes, "%x - %H:%M:%S", info);
+    return rawtime;
+}
 
 void warn_for_errors()
 {

--- a/C/lib/pmu.c
+++ b/C/lib/pmu.c
@@ -36,7 +36,7 @@
  *      Author: Ferad Zyulkyarov <ferad.zyulkyzrov@bsc.es>
  */
 
-#include "../include/pmu.h"
+#include "pmu.h"
 #include <stdlib.h>
 #include <linux/perf_event.h>
 #include <syscall.h>

--- a/C/lib/tools.c
+++ b/C/lib/tools.c
@@ -35,7 +35,7 @@ void inject_cpu_error(unsigned char* start, ADDRVALUE expected_value, Strategy_t
 
 void inject_gpu_error(unsigned char* start, ADDRVALUE expected_value, Strategy_t s)
 {
-#ifdef INJECT_ERR
+#if defined(INJECT_ERR) && defined(USE_CUDA)
     if (s != SIMPLE)
     {
         int riter = rand()%10 + 1;
@@ -78,6 +78,16 @@ bool check_cpu_mem(ADDRVALUE* buffer,
 
         buffer[word] = new_value;
     }
+}
+
+bool check_gpu_mem(ADDRVALUE* buffer,
+                   unsigned long long num_bytes,
+                   ADDRVALUE expected_value,
+                   ADDRVALUE new_value)
+{
+#if defined(USE_CUDA)
+    check_gpu_stub(buffer, num_bytes, expected_value, new_value);
+#endif
 }
 
 void simple_memory_test()
@@ -152,6 +162,7 @@ void zero_one_test()
         inject_gpu_error(gpu_mem, expected_value, ZERO);
 
         check_cpu_mem(cpu_mem, NumBytesCPU, expected_value, ~expected_value);
+        check_gpu_mem(gpu_mem, NumBytesGPU, expected_value, ~expected_value);
 
         expected_value = ~expected_value;
 

--- a/C/lib/tools.c
+++ b/C/lib/tools.c
@@ -390,15 +390,7 @@ void sigint_signal_handler(int signum)
 	log_message("STOP,SIGINT");
 }
 
-time_t get_formatted_timestamp(char* out_time_formatted, unsigned char num_bytes)
-{
-	time_t rawtime;
-	struct tm *info;
-	time(&rawtime);
-	info = localtime(&rawtime);
-	strftime(out_time_formatted, num_bytes, "%x - %H:%M:%S", info);
-	return rawtime;
-}
+
 
 void daemon_pid_write_to_file(pid_t pid)
 {
@@ -454,46 +446,6 @@ void daemon_pid_delete_file()
 	}
 }
 
-int read_temperature()
-{
-    int fd, fd_err, core = 0, ierr;
-    uint64_t temp;
-    char msr_file[32];
-    memset(msr_file, 0, 32);
 
-#ifdef SYS_getcpu
-    if (syscall(SYS_getcpu, &core, NULL, NULL) < 0) {
-        core = 0;
-    }
-#endif
-    
-    fd_err = open(ErrFile, O_WRONLY|O_CREAT|O_APPEND, 0666);
-    
-    snprintf(msr_file, 31, "/dev/cpu/%u/msr", core);
-    fd = open(msr_file, O_RDONLY);
-    if (fd == -1) {
-        ierr = errno;
-        dprintf(fd_err, "could not OPEN msr file: %s\n", strerror(ierr));
-        ierr = 0;
-        return -1;
-    }
-    
-    ierr = pread(fd, &temp, sizeof(temp), TEMP_FIELD_OFFSET);
-    if (ierr == -1) {
-        ierr = errno;
-        dprintf(fd_err, "could not READ msr file: %s\n", strerror(ierr));
-        ierr = 0;
-        return -1;
-    }
-
-    temp &= TEMP_FIELD_MASK;
-    temp >>= TEMP_FIELD_LOW_BIT;
-    temp = TCC_ACT_TEMP - temp;
-
-    close(fd_err);
-    close(fd);
-
-	return temp;
-}
 
 

--- a/C/lib/tools.c
+++ b/C/lib/tools.c
@@ -18,7 +18,7 @@ unsigned char* random_ptr_inside(unsigned char* start, unsigned long long size)
 
 unsigned char* align_to_addrvalue(unsigned char* ptr_data)
 {
-    uintptr_t ptrmask = sizeof(uintptr_t)-1;// TODO should we take the sizeof ADDRVALUE here?
+    uintptr_t ptrmask = sizeof(ADDRVALUE)-1;
     return (unsigned char*) ((uintptr_t)ptr_data & ~ptrmask);
 }
 
@@ -33,15 +33,14 @@ void inject_cpu_error(unsigned char* start, ADDRVALUE expected_value, Strategy_t
 #ifdef INJECT_ERR
     unsigned char *ptr_data = NULL;
 
-    if (inject_dice_roll()) { // FIXME the caller should decide to inject or not
+    if (inject_dice_roll()) { // FIXME the caller should decide when to inject
         switch (s) {
         case SIMPLE:
             break;
         case ZERO:
             ptr_data = random_ptr_inside(start, NumBytesCPU);
             memset(ptr_data, 0x1, 1);
-            // TODO ask if this is correct;
-            // We write to an address and print a different one.
+            // We print the ADDRVALUE-aligned address to match the error report
             ptr_data = align_to_addrvalue(ptr_data);
             break;
         case RANDOM:
@@ -67,7 +66,7 @@ void inject_gpu_error(unsigned char* start, ADDRVALUE expected_value, Strategy_t
     unsigned char *ptr_data = NULL;
     cudaError_t err;
 
-    if (inject_dice_roll()) { // FIXME the caller should decide to inject or not
+    if (inject_dice_roll()) { // FIXME the caller should decide when to inject
         switch (s) {
         case SIMPLE:
             break;
@@ -81,8 +80,7 @@ void inject_gpu_error(unsigned char* start, ADDRVALUE expected_value, Strategy_t
                         cudaGetErrorName(err), cudaGetErrorString(err));
                 log_message(msg);
             }
-            // TODO ask if this is correct;
-            // We write to an address and print a different one.
+            // We print the ADDRVALUE-aligned address to match the error report
             ptr_data = align_to_addrvalue(ptr_data);
             break;
         case RANDOM:

--- a/C/lib/tools.cu
+++ b/C/lib/tools.cu
@@ -24,10 +24,10 @@ void check_gpu_kernel(uintptr_t* buffer,
     }
 }
 
-void check_gpu_mem(uintptr_t* buffer,
-                   unsigned long long num_bytes,
-                   uintptr_t expected_value,
-                   uintptr_t new_value)
+void check_gpu_stub(uintptr_t* buffer,
+                    unsigned long long num_bytes,
+                    uintptr_t expected_value,
+                    uintptr_t new_value)
 {
     const long unsigned num_words = num_bytes / sizeof(uintptr_t);
     const int block_size = 128;

--- a/C/lib/tools.cu
+++ b/C/lib/tools.cu
@@ -1,0 +1,37 @@
+#include <cstdint>
+#include <cstdio>
+
+#include "MemoryReliability_decl.cuh"
+
+__global__
+void check_gpu_kernel(uintptr_t* buffer,
+                      const long unsigned num_words,
+                      uintptr_t expected_value,
+                      uintptr_t new_value)
+{
+    for (long unsigned word = blockIdx.x * blockDim.x + threadIdx.x;
+                       word < num_words;
+                       word += gridDim.x * blockDim.x)
+    {
+        uintptr_t actual_value = buffer[word];
+        if (actual_value != expected_value)
+        {
+            printf("ERROR, %p, %p, %p\n", &buffer[word], actual_value, expected_value);
+            //log_error(&buffer[word], actual_value, expected_value);
+        }
+
+        buffer[word] = new_value;
+    }
+}
+
+void check_gpu_mem(uintptr_t* buffer,
+                   unsigned long long num_bytes,
+                   uintptr_t expected_value,
+                   uintptr_t new_value)
+{
+    const long unsigned num_words = num_bytes / sizeof(uintptr_t);
+    const int block_size = 128;
+    const int grid_size = (num_words + block_size - 1) / block_size;
+    check_gpu_kernel<<<grid_size, block_size>>>
+            (buffer, num_words, expected_value, new_value);
+}

--- a/C/lib/tools.cu
+++ b/C/lib/tools.cu
@@ -1,7 +1,32 @@
 #include <cstdint>
 #include <cstdio>
+#include <cuda_runtime.h>
 
 #include "MemoryReliability_decl.cuh"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "logging.h"
+#ifdef __cplusplus
+};
+#endif
+
+__device__ __managed__ unsigned int fault_masking = 0;
+__device__ __managed__ uintptr_t* faulting_addr;
+__device__ __managed__ uintptr_t faulting_value;
+
+__device__
+bool is_first_error()
+{
+   return !atomicCAS(&fault_masking, 0, 1);
+}
+
+__host__
+bool report_error()
+{
+   return (fault_masking == 1) ? true : false;
+}
 
 __global__
 void check_gpu_kernel(uintptr_t* buffer,
@@ -16,8 +41,12 @@ void check_gpu_kernel(uintptr_t* buffer,
         uintptr_t actual_value = buffer[word];
         if (actual_value != expected_value)
         {
-            printf("ERROR, %p, %p, %p\n", &buffer[word], actual_value, expected_value);
-            //log_error(&buffer[word], actual_value, expected_value);
+            // Check if errors are masked:
+            if (is_first_error())
+            {
+                faulting_addr = &buffer[word];
+                faulting_value = actual_value;
+            }
         }
 
         buffer[word] = new_value;
@@ -29,9 +58,23 @@ void check_gpu_stub(uintptr_t* buffer,
                     uintptr_t expected_value,
                     uintptr_t new_value)
 {
+    // We only report the first error, the rest are ignored
+    fault_masking = 0;
+
     const long unsigned num_words = num_bytes / sizeof(uintptr_t);
     const int block_size = 128;
     const int grid_size = (num_words + block_size - 1) / block_size;
     check_gpu_kernel<<<grid_size, block_size>>>
             (buffer, num_words, expected_value, new_value);
+    cudaError_t err = cudaDeviceSynchronize();
+    if (err != cudaSuccess)
+    {
+        char msg[255];
+        sprintf(msg, "ERROR_INFO, cudaDeviceSynchronize reported an error: (%s:%s).",
+                      cudaGetErrorName(err), cudaGetErrorString(err));
+        log_message(msg);
+    }
+
+    if (report_error())
+        log_error(faulting_addr, faulting_value, expected_value);
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SDCfinder
+[![pipeline status](https://gitlab.com/bsc-gcoe/SDCfinder/badges/master/pipeline.svg)](https://gitlab.com/bsc-gcoe/SDCfinder/commits/master)
 
 This tool aims to detect Silent Data Corruption (SDC) ocurring in
 supercomputers and large datacenters. The current implementation is in C but we


### PR DESCRIPTION
First of all it's still in WIP.

- Separates CPU & GPU memory checking into different functions.
- Added `--cpu` and `--gpu` flags for specifiying which checker we want to use (we can use both if we want)
- `-m` flag must be preceded by `--cpu` or `--gpu`. It cannot be specified alone. (`--cpu -m 1024 --gpu -m 1024` is correct. `-m 1024 --cpu` it is not)
- When GPU kernel finds an erro, it prints that error to `stdout`. If we want that error to be printed to the `logging` file I will have to make some modifications. (Main reason this PR it's still in WIP)

Closes #5 